### PR TITLE
Working demos on webcomponents.org

### DIFF
--- a/demos/webpack.config.js
+++ b/demos/webpack.config.js
@@ -28,7 +28,18 @@ const config = merge(
       host: '0.0.0.0',
       disableHostCheck: true,
     },
-    plugins: [new CopyWebpackPlugin(['analysis.json', 'assets/*.*', '**/*.css']), ...demoHtmls],
+    plugins: [
+      new CopyWebpackPlugin(['assets/*.*', '**/*.css']),
+      new CopyWebpackPlugin([
+        {
+          from: 'analysis.json',
+          transform: (analysis) => {
+            return analysis.toString().replace(/https:\/\/openlayers-elements.netlify.com\//, '')
+          },
+        },
+      ]),
+      ...demoHtmls,
+    ],
   },
 )
 

--- a/demos/webpack.config.js
+++ b/demos/webpack.config.js
@@ -34,7 +34,7 @@ const config = merge(
         {
           from: 'analysis.json',
           transform: (analysis) => {
-            return analysis.toString().replace(/https:\/\/openlayers-elements.netlify.com\//, '')
+            return analysis.toString().replace(/https:\/\/openlayers-elements.netlify.com\//g, '')
           },
         },
       ]),

--- a/elements/openlayers-elements/ol-control.ts
+++ b/elements/openlayers-elements/ol-control.ts
@@ -28,7 +28,7 @@ import {OlMapPart} from './ol-map-part'
  * | --map-button-control-left | Left CSS offset |
  * | --map-button-control-right | Right CSS offset |
  *
- * @demo demo/control.html
+ * @demo https://openlayers-elements.netlify.com/demo/control.html
  * @customElement
  */
 export default class OlControl extends OlMapPart<Control> {

--- a/elements/openlayers-elements/ol-layer-geojson.ts
+++ b/elements/openlayers-elements/ol-layer-geojson.ts
@@ -6,8 +6,8 @@ import OlLayerVector from './ol-layer-vector'
 /**
  * A layer which loads features from a GeoJSON input
  *
- * @demo demo/select.html
- * @demo demo/markers.html Combined with markers
+ * @demo https://openlayers-elements.netlify.com/https://openlayers-elements.netlify.com/demo/select.html
+ * @demo https://openlayers-elements.netlify.com/demo/markers.html Combined with markers
  * @customElement
  */
 export default class OlLayerGeoJson extends OlLayerVector {

--- a/elements/openlayers-elements/ol-layer-geojson.ts
+++ b/elements/openlayers-elements/ol-layer-geojson.ts
@@ -6,7 +6,7 @@ import OlLayerVector from './ol-layer-vector'
 /**
  * A layer which loads features from a GeoJSON input
  *
- * @demo https://openlayers-elements.netlify.com/https://openlayers-elements.netlify.com/demo/select.html
+ * @demo https://openlayers-elements.netlify.com/demo/select.html
  * @demo https://openlayers-elements.netlify.com/demo/markers.html Combined with markers
  * @customElement
  */

--- a/elements/openlayers-elements/ol-layer-openstreetmap.ts
+++ b/elements/openlayers-elements/ol-layer-openstreetmap.ts
@@ -6,8 +6,8 @@ import OlLayerBase from './ol-layer-base'
  * A basic OpenStreetMap tile layer
  *
  * @customElement
- * @demo demo/ol-map.html Standard map
- * @demo demo/swiss-topo.html Mix with swisstopo elements
+ * @demo https://openlayers-elements.netlify.com/demo/ol-map.html Standard map
+ * @demo https://openlayers-elements.netlify.com/demo/swiss-topo.html Mix with swisstopo elements
  */
 export default class OlLayerOpenstreetmap extends OlLayerBase<TileLayer> {
   protected async _createLayer() {

--- a/elements/openlayers-elements/ol-layer-xyz.ts
+++ b/elements/openlayers-elements/ol-layer-xyz.ts
@@ -6,7 +6,7 @@ import OlLayerBase from './ol-layer-base'
 /**
  * A simple layer element, sourcing from a raster tile server using X/Y/Z coordinates
  *
- * @demo demo/xyz.html
+ * @demo https://openlayers-elements.netlify.com/demo/xyz.html
  * @customElement
  */
 export default class OlLayerXyz extends OlLayerBase<TileLayer> {

--- a/elements/openlayers-elements/ol-map.ts
+++ b/elements/openlayers-elements/ol-map.ts
@@ -36,7 +36,7 @@ import OlLayerBase from './ol-layer-base'
  *
  * If `x` and `y` are set, the geographic coordinates are ignored.
  *
- * @demo demo/ol-map.html
+ * @demo https://openlayers-elements.netlify.com/demo/ol-map.html
  * @appliesMixin ChildObserverMixin
  * @customElement
  */

--- a/elements/openlayers-elements/ol-marker-icon.ts
+++ b/elements/openlayers-elements/ol-marker-icon.ts
@@ -31,7 +31,7 @@ import IconOptions = olx.style.IconOptions
  *
  * For an in-depth description of individual properties go to OpenLayer's docs for [ol/Style/Icon](https://openlayers.org/en/latest/apidoc/module-ol_style_Icon.html)
  *
- * @demo demo/markers.html
+ * @demo https://openlayers-elements.netlify.com/demo/markers.html
  */
 export default class OlMarkerIcon extends OlFeature {
   /**

--- a/elements/openlayers-elements/ol-select.ts
+++ b/elements/openlayers-elements/ol-select.ts
@@ -13,7 +13,7 @@ import OlInteraction from './ol-interaction'
  * ```
  *
  * @customElement
- * @demo demo/select.html
+ * @demo https://openlayers-elements.netlify.com/demo/select.html
  */
 export class OlSelect extends OlInteraction {
   /**

--- a/elements/swisstopo-elements/swisstopo-reprojected.ts
+++ b/elements/swisstopo-elements/swisstopo-reprojected.ts
@@ -11,7 +11,7 @@ import SwisstopoElement from './swisstopo-element'
  * Apparently this style of layer source does not work with every one of Swiss layers. If you get 404s (blank map),
  * use the [`swisstopo-wmts` layer](#/elements/SwissTopoWMTS)
  *
- * @demo demo/swiss-reprojected.html
+ * @demo https://openlayers-elements.netlify.com/demo/swiss-reprojected.html
  * @appliesMixin SwisstopoElementMixin
  * @customElement
  */

--- a/elements/swisstopo-elements/swisstopo-wmts.ts
+++ b/elements/swisstopo-elements/swisstopo-wmts.ts
@@ -16,7 +16,7 @@ type Projections = 'EPSG:3857' | 'EPSG:21718' | 'EPSG:2056' | 'EPSG:4329'
  *
  * [wmts-list]: http://api3.geo.admin.ch/services/sdiservices.html#supported-projections
  *
- * @demo demo/swiss-topo.html
+ * @demo https://openlayers-elements.netlify.com/demo/swiss-topo.html
  * @appliesMixin SwisstopoElementMixin
  * @customElement
  */


### PR DESCRIPTION
Adds absolute URLs to the published demos. Hopefully this way the demos will be directly accessible from webcomponents.org.

When built or started with `webpack-dev-server` the URL is stripped to serve the local files